### PR TITLE
Generate typescript type definitions for node clients

### DIFF
--- a/docker/grpcgen-node/Dockerfile
+++ b/docker/grpcgen-node/Dockerfile
@@ -15,6 +15,7 @@ RUN n ${NODE_VERSION} && \
     n use ${NODE_VERSION}
 
 RUN npm install -g grpc-tools@${GRPC_VERSION}
+RUN npm install -g ts-protoc-gen@0.12.0
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN mkdir -p /src /out

--- a/docker/grpcgen-node/docker-entrypoint.sh
+++ b/docker/grpcgen-node/docker-entrypoint.sh
@@ -1,4 +1,11 @@
 #!/bin/sh
 for proto in "$@"; do
-    grpc_tools_node_protoc -I/src --js_out=import_style=commonjs,binary:/out --grpc_out=/out --plugin=protoc-gen-grpc=`which grpc_tools_node_protoc_plugin` "$proto"
+    grpc_tools_node_protoc \
+        -I/src \
+        --js_out=import_style=commonjs,binary:/out \
+        --grpc_out=/out \
+        --ts_out="service=grpc-node:/out" \
+        --plugin="protoc-gen-ts=$(which protoc-gen-ts)" \
+        --plugin="protoc-gen-grpc=$(which grpc_tools_node_protoc_plugin)" \
+        "$proto"
 done


### PR DESCRIPTION
Uses https://github.com/improbable-eng/ts-protoc-gen to generate typescript type definitions for node clients.